### PR TITLE
define Py_LIMITED_API by default

### DIFF
--- a/hpy-api/hpy_devel/include/cpython/hpy.h
+++ b/hpy-api/hpy_devel/include/cpython/hpy.h
@@ -6,7 +6,7 @@
 
 /* XXX: it would be nice if we could include hpy.h WITHOUT bringing in all the
    stuff from Python.h, to make sure that people don't use the CPython API by
-   mistake. How to achieve it, though? */
+   mistake. How to achieve it, though? Is defining Py_LIMITED_API enough? */
 
 /* XXX: should we:
  *    - enforce PY_SSIZE_T_CLEAN in hpy

--- a/hpy-api/hpy_devel/include/hpy.h
+++ b/hpy-api/hpy_devel/include/hpy.h
@@ -4,6 +4,13 @@
 #ifdef HPY_UNIVERSAL_ABI
 #    include "universal/hpy.h"
 #else
+/*
+ *   By default, limit the CPython C-API. If you wish to use the
+ *   extended API, you must #include "Python.h" before #including this file
+ */
+#    ifndef Py_PYTHON_H
+#    define Py_LIMITED_API
+#    endif
 #    include "cpython/hpy.h"
 #endif
 


### PR DESCRIPTION
As laid out in the [design goals](https://github.com/pyhandle/hpy/blob/master/docs/api.md#general-design-guidelines), define the limited C-API. This would go a long way to making code that uses hpy less dependent on implementation details, and would also encourage developers to use the PEP 425 limited api tag "api3" for c-extension modules.