### PR TITLE
Change handle content type to 'void *'.

### DIFF
--- a/hpy-api/hpy_devel/include/universal/hpy.h
+++ b/hpy-api/hpy_devel/include/universal/hpy.h
@@ -7,7 +7,7 @@
 
 typedef intptr_t HPy_ssize_t;
 
-struct _HPy_s { HPy_ssize_t _i; };
+struct _HPy_s { void* _i; };
 typedef struct _HPy_s HPy;
 
 typedef struct _HPyContext_s *HPyContext;
@@ -16,14 +16,14 @@ typedef struct _object *(*_HPy_CPyCFunction)(struct _object *self,
                                              struct _object *args);
 
 #define _HPy_HIDDEN   __attribute__((visibility("hidden")))
-#define HPy_NULL ((HPy){0})
-#define HPy_IsNull(x) ((x)._i == 0)
+#define HPy_NULL ((HPy){NULL})
+#define HPy_IsNull(x) ((x)._i == NULL)
 
 // XXX: we need to decide whether these are part of the official API or not,
 // and maybe introduce a better naming convetion. For now, they are needed for
 // ujson
-static inline HPy HPy_FromVoidP(void *p) { return (HPy){(HPy_ssize_t)p}; }
-static inline void* HPy_AsVoidP(HPy h) { return (void*)h._i; }
+static inline HPy HPy_FromVoidP(void *p) { return (HPy){p}; }
+static inline void* HPy_AsVoidP(HPy h) { return h._i; }
 
 
 #include "meth.h"


### PR DESCRIPTION
This changes the type of member `_i` (`struct _HPy_s`) to `void *`.
The reason for this change is that `void *` is a more abstract type and does not force a runtime implementation to really represent their handles via integers.
In particular, in GraalVM's implementation of Python, we do not run the C code natively. Therefore, a pointer would allow us to keep the handle virtual whereas an integer will force us to actually allocate the handle.

For runtime implementations written in C/C++, the change should not impose any overhead since the `void *` can still be casted to `HPy_ssize_t`.