### PR TITLE
Implement O for HPyArg_Parse.

### DIFF
--- a/hpy/devel/include/cpython/hpy.h
+++ b/hpy/devel/include/cpython/hpy.h
@@ -129,6 +129,11 @@ HPyArg_Parse(HPyContext ctx, HPy *args, Py_ssize_t nargs, const char *fmt, ...)
             *output = value;
             break;
         }
+        case 'O': {
+            HPy *output = va_arg(vl, HPy *);
+            *output = args[i];
+            break;
+        }
         default:
             abort();  // XXX
         }

--- a/hpy/universal/src/api.c
+++ b/hpy/universal/src/api.c
@@ -180,6 +180,11 @@ ctx_Arg_Parse(HPyContext ctx, HPy *args, Py_ssize_t nargs,
             *output = value;
             break;
         }
+        case 'O': {
+            HPy *output = va_arg(vl, HPy *);
+            *output = args[i];
+            break;
+        }
         default:
             abort();  // XXX
         }

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -116,6 +116,22 @@ class TestBasic(HPyTest):
         """)
         assert mod.f(4, 5, 6, 7, 8) == 45678
 
+    def test_many_handle_arguments(self):
+        mod = self.make_module("""
+            HPy_DEF_METH_VARARGS(f)
+            static HPy f_impl(HPyContext ctx, HPy self,
+                              HPy *args, HPy_ssize_t nargs)
+            {
+                HPy a, b;
+                if (!HPyArg_Parse(ctx, args, nargs, "OO", &a, &b))
+                    return HPy_NULL;
+                return HPyNumber_Add(ctx, a, b);
+            }
+            @EXPORT f HPy_METH_VARARGS
+            @INIT
+        """)
+        assert mod.f("a", "b") == "ab"
+
     def test_close(self):
         mod = self.make_module("""
             HPy_DEF_METH_O(f)


### PR DESCRIPTION
The O format returns an HPy handle, which is the equivalent of PyObject in HPy. Conversion of handles returned to PyObjects should be performed explicitly when needed.