### PR TITLE
Improve autogen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# HPy autogen
+tools/autogen_pypy.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/hpy/devel/include/common/autogen_impl.h
+++ b/hpy/devel/include/common/autogen_impl.h
@@ -48,6 +48,46 @@ HPyAPI_STORAGE int _HPy_IMPL_NAME(Object_IsTrue)(HPyContext ctx, HPy h)
     return PyObject_IsTrue(_h2py(h));
 }
 
+HPyAPI_STORAGE HPy _HPy_IMPL_NAME_NOPREFIX(GetAttr)(HPyContext ctx, HPy obj, HPy name)
+{
+    return _py2h(PyObject_GetAttr(_h2py(obj), _h2py(name)));
+}
+
+HPyAPI_STORAGE HPy _HPy_IMPL_NAME_NOPREFIX(GetAttr_s)(HPyContext ctx, HPy obj, const char *name)
+{
+    return _py2h(PyObject_GetAttrString(_h2py(obj), name));
+}
+
+HPyAPI_STORAGE int _HPy_IMPL_NAME_NOPREFIX(HasAttr)(HPyContext ctx, HPy obj, HPy name)
+{
+    return PyObject_HasAttr(_h2py(obj), _h2py(name));
+}
+
+HPyAPI_STORAGE int _HPy_IMPL_NAME_NOPREFIX(HasAttr_s)(HPyContext ctx, HPy obj, const char *name)
+{
+    return PyObject_HasAttrString(_h2py(obj), name);
+}
+
+HPyAPI_STORAGE int _HPy_IMPL_NAME_NOPREFIX(SetAttr)(HPyContext ctx, HPy obj, HPy name, HPy value)
+{
+    return PyObject_SetAttr(_h2py(obj), _h2py(name), _h2py(value));
+}
+
+HPyAPI_STORAGE int _HPy_IMPL_NAME_NOPREFIX(SetAttr_s)(HPyContext ctx, HPy obj, const char *name, HPy value)
+{
+    return PyObject_SetAttrString(_h2py(obj), name, _h2py(value));
+}
+
+HPyAPI_STORAGE HPy _HPy_IMPL_NAME_NOPREFIX(GetItem)(HPyContext ctx, HPy obj, HPy key)
+{
+    return _py2h(PyObject_GetItem(_h2py(obj), _h2py(key)));
+}
+
+HPyAPI_STORAGE int _HPy_IMPL_NAME_NOPREFIX(SetItem)(HPyContext ctx, HPy obj, HPy key, HPy value)
+{
+    return PyObject_SetItem(_h2py(obj), _h2py(key), _h2py(value));
+}
+
 HPyAPI_STORAGE int _HPy_IMPL_NAME(Bytes_Check)(HPyContext ctx, HPy h)
 {
     return PyBytes_Check(_h2py(h));

--- a/hpy/devel/include/common/implementation.h
+++ b/hpy/devel/include/common/implementation.h
@@ -1,0 +1,49 @@
+#include "common/autogen_impl.h"
+
+/* object.h */
+
+HPyAPI_STORAGE HPy
+_HPy_IMPL_NAME_NOPREFIX(GetItem_i)(HPyContext ctx, HPy obj, HPy_ssize_t idx) {
+    PyObject* key = PyLong_FromSsize_t(idx);
+    if (key == NULL)
+        return HPy_NULL;
+    HPy result = _py2h(PyObject_GetItem(_h2py(obj), key));
+    Py_DECREF(key);
+    return result;
+}
+
+HPyAPI_STORAGE HPy
+_HPy_IMPL_NAME_NOPREFIX(GetItem_s)(HPyContext ctx, HPy obj, const char *key) {
+    PyObject* key_o = PyUnicode_FromString(key);
+    if (key_o == NULL)
+        return HPy_NULL;
+    HPy result = _py2h(PyObject_GetItem(_h2py(obj), key_o));
+    Py_DECREF(key_o);
+    return result;
+}
+
+HPyAPI_STORAGE int
+_HPy_IMPL_NAME_NOPREFIX(SetItem_i)(HPyContext ctx, HPy obj, HPy_ssize_t idx, HPy value) {
+    PyObject* key = PyLong_FromSsize_t(idx);
+    if (key == NULL)
+        return -1;
+    int result = PyObject_SetItem(_h2py(obj), key, _h2py(value));
+    Py_DECREF(key);
+    return result;
+}
+
+HPyAPI_STORAGE int
+_HPy_IMPL_NAME_NOPREFIX(SetItem_s)(HPyContext ctx, HPy obj, const char *key, HPy value) {
+    PyObject* key_o = PyUnicode_FromString(key);
+    if (key_o == NULL)
+        return -1;
+    int result = PyObject_SetItem(_h2py(obj), key_o, _h2py(value));
+    Py_DECREF(key_o);
+    return result;
+}
+
+HPyAPI_STORAGE int
+_HPy_IMPL_NAME(Err_Occurred)(HPyContext ctx) {
+    return PyErr_Occurred() ? 1 : 0;
+}
+

--- a/hpy/devel/include/cpython/hpy.h
+++ b/hpy/devel/include/cpython/hpy.h
@@ -94,41 +94,6 @@ HPy_Close(HPyContext ctx, HPy handle)
 /* object.h */
 
 HPyAPI_FUNC(HPy)
-HPy_GetAttr(HPyContext ctx, HPy obj, HPy name) {
-  return _py2h(PyObject_GetAttr(_h2py(obj), _h2py(name)));
-}
-
-HPyAPI_FUNC(HPy)
-HPy_GetAttr_s(HPyContext ctx, HPy obj, const char *name) {
-  return _py2h(PyObject_GetAttrString(_h2py(obj), name));
-}
-
-HPyAPI_FUNC(int)
-HPy_HasAttr(HPyContext ctx, HPy obj, HPy name) {
-  return PyObject_HasAttr(_h2py(obj), _h2py(name));
-}
-
-HPyAPI_FUNC(int)
-HPy_HasAttr_s(HPyContext ctx, HPy obj, const char *name) {
-  return PyObject_HasAttrString(_h2py(obj), name);
-}
-
-HPyAPI_FUNC(int)
-HPy_SetAttr(HPyContext ctx, HPy obj, HPy name, HPy value) {
-  return PyObject_SetAttr(_h2py(obj), _h2py(name), _h2py(value));
-}
-
-HPyAPI_FUNC(int)
-HPy_SetAttr_s(HPyContext ctx, HPy obj, const char *name, HPy value) {
-  return PyObject_SetAttrString(_h2py(obj), name, _h2py(value));
-}
-
-HPyAPI_FUNC(HPy)
-HPy_GetItem(HPyContext ctx, HPy obj, HPy key) {
-  return _py2h(PyObject_GetItem(_h2py(obj), _h2py(key)));
-}
-
-HPyAPI_FUNC(HPy)
 HPy_GetItem_i(HPyContext ctx, HPy obj, HPy_ssize_t idx) {
   PyObject* key = PyLong_FromSsize_t(idx);
   if (key == NULL)
@@ -146,11 +111,6 @@ HPy_GetItem_s(HPyContext ctx, HPy obj, const char *key) {
   HPy result = _py2h(PyObject_GetItem(_h2py(obj), key_o));
   Py_DECREF(key_o);
   return result;
-}
-
-HPyAPI_FUNC(int)
-HPy_SetItem(HPyContext ctx, HPy obj, HPy key, HPy value) {
-  return PyObject_SetItem(_h2py(obj), _h2py(key), _h2py(value));
 }
 
 HPyAPI_FUNC(int)
@@ -216,7 +176,9 @@ HPy_AsPyObject(HPyContext ctx, HPy h)
  *
  */
 #define _HPy_IMPL_NAME(name) HPy##name
+#define _HPy_IMPL_NAME_NOPREFIX(name) HPy_##name
 #include "../common/autogen_impl.h"
+#undef _HPy_IMPL_NAME_NOPREFIX
 #undef _HPy_IMPL_NAME
 
 // include runtime functions

--- a/hpy/devel/include/cpython/hpy.h
+++ b/hpy/devel/include/cpython/hpy.h
@@ -91,53 +91,6 @@ HPy_Close(HPyContext ctx, HPy handle)
     Py_XDECREF(_h2py(handle));
 }
 
-/* object.h */
-
-HPyAPI_FUNC(HPy)
-HPy_GetItem_i(HPyContext ctx, HPy obj, HPy_ssize_t idx) {
-  PyObject* key = PyLong_FromSsize_t(idx);
-  if (key == NULL)
-    return HPy_NULL;
-  HPy result = _py2h(PyObject_GetItem(_h2py(obj), key));
-  Py_DECREF(key);
-  return result;
-}
-
-HPyAPI_FUNC(HPy)
-HPy_GetItem_s(HPyContext ctx, HPy obj, const char *key) {
-  PyObject* key_o = PyUnicode_FromString(key);
-  if (key_o == NULL)
-    return HPy_NULL;
-  HPy result = _py2h(PyObject_GetItem(_h2py(obj), key_o));
-  Py_DECREF(key_o);
-  return result;
-}
-
-HPyAPI_FUNC(int)
-HPy_SetItem_i(HPyContext ctx, HPy obj, HPy_ssize_t idx, HPy value) {
-  PyObject* key = PyLong_FromSsize_t(idx);
-  if (key == NULL)
-    return -1;
-  int result = PyObject_SetItem(_h2py(obj), key, _h2py(value));
-  Py_DECREF(key);
-  return result;
-}
-
-HPyAPI_FUNC(int)
-HPy_SetItem_s(HPyContext ctx, HPy obj, const char *key, HPy value) {
-  PyObject* key_o = PyUnicode_FromString(key);
-  if (key_o == NULL)
-    return -1;
-  int result = PyObject_SetItem(_h2py(obj), key_o, _h2py(value));
-  Py_DECREF(key_o);
-  return result;
-}
-
-HPyAPI_FUNC(int)
-HPyErr_Occurred(HPyContext ctx) {
-  return PyErr_Occurred() ? 1 : 0;
-}
-
 /* moduleobject.h */
 typedef PyModuleDef HPyModuleDef;
 
@@ -177,7 +130,7 @@ HPy_AsPyObject(HPyContext ctx, HPy h)
  */
 #define _HPy_IMPL_NAME(name) HPy##name
 #define _HPy_IMPL_NAME_NOPREFIX(name) HPy_##name
-#include "../common/autogen_impl.h"
+#include "../common/implementation.h"
 #undef _HPy_IMPL_NAME_NOPREFIX
 #undef _HPy_IMPL_NAME
 

--- a/hpy/universal/src/api.c
+++ b/hpy/universal/src/api.c
@@ -91,41 +91,6 @@ ctx_Module_Create(HPyContext ctx, HPyModuleDef *hpydef)
 /* HPy object protocol */
 
 static HPy
-ctx_GetAttr(HPyContext ctx, HPy obj, HPy name) {
-  return _py2h(PyObject_GetAttr(_h2py(obj), _h2py(name)));
-}
-
-static HPy
-ctx_GetAttr_s(HPyContext ctx, HPy obj, const char *name) {
-  return _py2h(PyObject_GetAttrString(_h2py(obj), name));
-}
-
-static int
-ctx_HasAttr(HPyContext ctx, HPy obj, HPy name) {
-  return PyObject_HasAttr(_h2py(obj), _h2py(name));
-}
-
-static int
-ctx_HasAttr_s(HPyContext ctx, HPy obj, const char *name) {
-  return PyObject_HasAttrString(_h2py(obj), name);
-}
-
-static int
-ctx_SetAttr(HPyContext ctx, HPy obj, HPy name, HPy value) {
-  return PyObject_SetAttr(_h2py(obj), _h2py(name), _h2py(value));
-}
-
-static int
-ctx_SetAttr_s(HPyContext ctx, HPy obj, const char *name, HPy value) {
-  return PyObject_SetAttrString(_h2py(obj), name, _h2py(value));
-}
-
-static HPy
-ctx_GetItem(HPyContext ctx, HPy obj, HPy key) {
-  return _py2h(PyObject_GetItem(_h2py(obj), _h2py(key)));
-}
-
-static HPy
 ctx_GetItem_i(HPyContext ctx, HPy obj, HPy_ssize_t idx) {
   PyObject* key = PyLong_FromSsize_t(idx);
   if (key == NULL)
@@ -143,11 +108,6 @@ ctx_GetItem_s(HPyContext ctx, HPy obj, const char *key) {
   HPy result = _py2h(PyObject_GetItem(_h2py(obj), key_o));
   Py_DECREF(key_o);
   return result;
-}
-
-static int
-ctx_SetItem(HPyContext ctx, HPy obj, HPy key, HPy value) {
-  return PyObject_SetItem(_h2py(obj), _h2py(key), _h2py(value));
 }
 
 static int
@@ -258,7 +218,9 @@ ctx_Dup(HPyContext ctx, HPy h)
  */
 #define HPyAPI_STORAGE static
 #define _HPy_IMPL_NAME(name) ctx_##name
+#define _HPy_IMPL_NAME_NOPREFIX(name) ctx_##name
 #include "common/autogen_impl.h"
+#undef _HPy_IMPL_NAME_NOPREFIX
 #undef _HPy_IMPL_NAME
 
 #include "autogen_ctx_def.h"

--- a/hpy/universal/src/api.c
+++ b/hpy/universal/src/api.c
@@ -88,53 +88,6 @@ ctx_Module_Create(HPyContext ctx, HPyModuleDef *hpydef)
     return _py2h(result);
 }
 
-/* HPy object protocol */
-
-static HPy
-ctx_GetItem_i(HPyContext ctx, HPy obj, HPy_ssize_t idx) {
-  PyObject* key = PyLong_FromSsize_t(idx);
-  if (key == NULL)
-    return HPy_NULL;
-  HPy result = _py2h(PyObject_GetItem(_h2py(obj), key));
-  Py_DECREF(key);
-  return result;
-}
-
-static HPy
-ctx_GetItem_s(HPyContext ctx, HPy obj, const char *key) {
-  PyObject* key_o = PyUnicode_FromString(key);
-  if (key_o == NULL)
-    return HPy_NULL;
-  HPy result = _py2h(PyObject_GetItem(_h2py(obj), key_o));
-  Py_DECREF(key_o);
-  return result;
-}
-
-static int
-ctx_SetItem_i(HPyContext ctx, HPy obj, HPy_ssize_t idx, HPy value) {
-  PyObject* key = PyLong_FromSsize_t(idx);
-  if (key == NULL)
-    return -1;
-  int result = PyObject_SetItem(_h2py(obj), key, _h2py(value));
-  Py_DECREF(key);
-  return result;
-}
-
-static int
-ctx_SetItem_s(HPyContext ctx, HPy obj, const char *key, HPy value) {
-  PyObject* key_o = PyUnicode_FromString(key);
-  if (key_o == NULL)
-    return -1;
-  int result = PyObject_SetItem(_h2py(obj), key_o, _h2py(value));
-  Py_DECREF(key_o);
-  return result;
-}
-
-static int
-ctx_Err_Occurred(HPyContext ctx) {
-  return PyErr_Occurred() ? 1 : 0;
-}
-
 /* HPyMeth */
 
 typedef HPy (*HPyMeth_NoArgs)(HPyContext, HPy self);
@@ -219,7 +172,7 @@ ctx_Dup(HPyContext ctx, HPy h)
 #define HPyAPI_STORAGE static
 #define _HPy_IMPL_NAME(name) ctx_##name
 #define _HPy_IMPL_NAME_NOPREFIX(name) ctx_##name
-#include "common/autogen_impl.h"
+#include "common/implementation.h"
 #undef _HPy_IMPL_NAME_NOPREFIX
 #undef _HPy_IMPL_NAME
 

--- a/tools/autogen.py
+++ b/tools/autogen.py
@@ -94,7 +94,11 @@ class Function:
             # HPy _HPy_API_NAME(Number_Add)(HPyContext ctx, HPy x, HPy y)
             newnode = deepcopy(self.node)
             typedecl = self._find_typedecl(newnode)
-            typedecl.declname = '_HPy_IMPL_NAME(%s)' % base_name     # rename the function
+            # rename the function
+            if self.name.startswith('HPy_'):
+                typedecl.declname = '_HPy_IMPL_NAME_NOPREFIX(%s)' % base_name
+            else:
+                typedecl.declname = '_HPy_IMPL_NAME(%s)' % base_name
             return toC(newnode)
         #
         def call(pyfunc, return_type):
@@ -204,21 +208,21 @@ class FuncDeclVisitor(pycparser.c_ast.NodeVisitor):
 SPECIAL_CASES = {
     'HPy_Dup': None,
     'HPy_Close': None,
-    'HPy_FromPyObject': None,
-    'HPy_GetAttr': None,
-    'HPy_GetAttr_s': None,
-    'HPy_HasAttr': None,
-    'HPy_HasAttr_s': None,
-    'HPy_SetAttr': None,
-    'HPy_SetAttr_s': None,
-    'HPy_GetItem': None,
+    'HPyModule_Create': None,
+    'HPy_GetAttr': 'PyObject_GetAttr',
+    'HPy_GetAttr_s': 'PyObject_GetAttrString',
+    'HPy_HasAttr': 'PyObject_HasAttr',
+    'HPy_HasAttr_s': 'PyObject_HasAttrString',
+    'HPy_SetAttr': 'PyObject_SetAttr',
+    'HPy_SetAttr_s': 'PyObject_SetAttrString',
+    'HPy_GetItem': 'PyObject_GetItem',
     'HPy_GetItem_i': None,
     'HPy_GetItem_s': None,
-    'HPy_SetItem': None,
+    'HPy_SetItem': 'PyObject_SetItem',
     'HPy_SetItem_i': None,
     'HPy_SetItem_s': None,
+    'HPy_FromPyObject': None,
     'HPy_AsPyObject': None,
-    'HPyModule_Create': None,
     '_HPy_CallRealFunctionFromTrampoline': None,
     'HPyErr_Occurred': None,
 }

--- a/tools/test_autogen.py
+++ b/tools/test_autogen.py
@@ -10,6 +10,7 @@ def autogen(tmpdir_factory):
         typedef int HPy;
         typedef int HPyContext;
         HPy h_None;
+        HPy HPy_Dup(HPyContext ctx, HPy h);
         HPy HPyNumber_Add(HPyContext ctx, HPy x, HPy y);
         HPy HPyLong_FromLong(HPyContext ctx, long value);
         char* HPyBytes_AsString(HPyContext ctx, HPy o);
@@ -37,6 +38,11 @@ class TestFunction:
             }
         """
         assert src_equal(x, expected)
+
+    def test_no_implementation(self, autogen):
+        func = autogen.get('HPy_Dup')
+        with pytest.raises(ValueError):
+            func.implementation()
 
     def test_implementation_hpy_types(self, autogen):
         func = autogen.get('HPyNumber_Add')


### PR DESCRIPTION
Reduce duplication between the 2 ABIs by:
* Allowing functions whose name isn't just like CPython's with an 'H' added to be auto-generated.
* Moving other duplicated implementations to `common/implementation.h`

Sadly, dealing with names like `HPy_Foo` required adding another macro. (autogen could only create implementations for `HPyFoo_Bar` so far) 

