### PR TITLE
Add 'd' format to HPyArg_ParseItem() and HPyFloat_AsDouble()

### DIFF
--- a/hpy/devel/include/common/autogen_impl.h
+++ b/hpy/devel/include/common/autogen_impl.h
@@ -33,6 +33,11 @@ HPyAPI_STORAGE HPy _HPy_IMPL_NAME(Float_FromDouble)(HPyContext ctx, double v)
     return _py2h(PyFloat_FromDouble(v));
 }
 
+HPyAPI_STORAGE double _HPy_IMPL_NAME(Float_AsDouble)(HPyContext ctx, HPy h)
+{
+    return PyFloat_AsDouble(_h2py(h));
+}
+
 HPyAPI_STORAGE HPy _HPy_IMPL_NAME_NOPREFIX(Add)(HPyContext ctx, HPy h1, HPy h2)
 {
     return _py2h(PyNumber_Add(_h2py(h1), _h2py(h2)));

--- a/hpy/devel/include/universal/autogen_ctx.h
+++ b/hpy/devel/include/universal/autogen_ctx.h
@@ -23,6 +23,7 @@ struct _HPyContext_s {
     HPy (*ctx_Long_FromUnsignedLongLong)(HPyContext ctx, unsigned long long v);
     long (*ctx_Long_AsLong)(HPyContext ctx, HPy h);
     HPy (*ctx_Float_FromDouble)(HPyContext ctx, double v);
+    double (*ctx_Float_AsDouble)(HPyContext ctx, HPy h);
     HPy (*ctx_Add)(HPyContext ctx, HPy h1, HPy h2);
     HPy (*ctx_Subtract)(HPyContext ctx, HPy h1, HPy h2);
     HPy (*ctx_Multiply)(HPyContext ctx, HPy h1, HPy h2);

--- a/hpy/devel/include/universal/autogen_trampolines.h
+++ b/hpy/devel/include/universal/autogen_trampolines.h
@@ -40,6 +40,10 @@ static inline HPy HPyFloat_FromDouble(HPyContext ctx, double v) {
      return ctx->ctx_Float_FromDouble ( ctx, v ); 
 }
 
+static inline double HPyFloat_AsDouble(HPyContext ctx, HPy h) {
+     return ctx->ctx_Float_AsDouble ( ctx, h ); 
+}
+
 static inline HPy HPy_Add(HPyContext ctx, HPy h1, HPy h2) {
      return ctx->ctx_Add ( ctx, h1, h2 ); 
 }

--- a/hpy/devel/src/runtime/argparse.c
+++ b/hpy/devel/src/runtime/argparse.c
@@ -23,15 +23,15 @@ int _HPyArg_ParseItem(HPyContext ctx, HPy current_arg, const char **fmt, va_list
         *output = value;
         break;
     }
-    /* case 'd': { */
-    /*     double* output = va_arg(vl, double *); */
-    /*     _BREAK_IF_OPTIONAL(current_arg); */
-    /*     double value = HPyFloat_AsDouble(ctx, current_arg); */
-    /*     if (value == -1.0 && HPy_ErrOccurred()) */
-    /*         return 0; */
-    /*     *output = value; */
-    /*     break; */
-    /* } */
+    case 'd': {
+        double* output = va_arg(vl, double *);
+        _BREAK_IF_OPTIONAL(current_arg);
+        double value = HPyFloat_AsDouble(ctx, current_arg);
+        if (value == -1.0 && HPyErr_Occurred(ctx))
+            return 0;
+        *output = value;
+        break;
+    }
     case 'O': {
         HPy *output = va_arg(vl, HPy *);
         _BREAK_IF_OPTIONAL(current_arg);

--- a/hpy/tools/autogen/public_api.h
+++ b/hpy/tools/autogen/public_api.h
@@ -27,6 +27,7 @@ HPy HPyLong_FromUnsignedLongLong(HPyContext ctx, unsigned long long v);
 
 long HPyLong_AsLong(HPyContext ctx, HPy h);
 HPy HPyFloat_FromDouble(HPyContext ctx, double v);
+double HPyFloat_AsDouble(HPyContext ctx, HPy h);
 
 /* abstract.h */
 HPy HPy_Add(HPyContext ctx, HPy h1, HPy h2);

--- a/hpy/universal/src/autogen_ctx_def.h
+++ b/hpy/universal/src/autogen_ctx_def.h
@@ -23,6 +23,7 @@ struct _HPyContext_s global_ctx = {
     .ctx_Long_FromUnsignedLongLong = &ctx_Long_FromUnsignedLongLong,
     .ctx_Long_AsLong = &ctx_Long_AsLong,
     .ctx_Float_FromDouble = &ctx_Float_FromDouble,
+    .ctx_Float_AsDouble = &ctx_Float_AsDouble,
     .ctx_Add = &ctx_Add,
     .ctx_Subtract = &ctx_Subtract,
     .ctx_Multiply = &ctx_Multiply,

--- a/test/test_argparse.py
+++ b/test/test_argparse.py
@@ -36,6 +36,14 @@ class TestParseItem(HPyTest):
         assert mod.f(1) == 1
         assert mod.f(-2) == -2
 
+    def test_d(self):
+        import pytest
+        mod = self.make_parse_item("d", "double", "HPyFloat_FromDouble")
+        assert mod.f(1.) == 1.
+        assert mod.f(-2) == -2.
+        with pytest.raises(TypeError):
+            mod.f("x")
+
     def test_O(self):
         mod = self.make_parse_item("O", "HPy", "HPy_Dup")
         assert mod.f("a") == "a"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -75,6 +75,19 @@ class TestBasic(HPyTest):
         """)
         assert mod.f(45) == 90
 
+    def test_float_asdouble(self):
+        mod = self.make_module("""
+            HPyDef_METH(f, "f", f_impl, HPyFunc_O)
+            static HPy f_impl(HPyContext ctx, HPy self, HPy arg)
+            {
+                double a = HPyFloat_AsDouble(ctx, arg);
+                return HPyFloat_FromDouble(ctx, a * 2.);
+            }
+            @EXPORT(f)
+            @INIT
+        """)
+        assert mod.f(1.) == 2.
+
     def test_wrong_number_of_arguments(self):
         import pytest
         mod = self.make_module("""


### PR DESCRIPTION
Create simple wrapper for `PyFloat_AsDouble()` and add the missing `d` format to argparse.