### PR TITLE
Keep test.support py2-compatible

### DIFF
--- a/test/support.py
+++ b/test/support.py
@@ -7,7 +7,8 @@ PY2 = sys.version_info[0] == 2
 
 def reindent(s, indent):
     s = textwrap.dedent(s)
-    return textwrap.indent(s, ' '*indent)
+    return ''.join(' '*indent + line if line.strip() else line
+        for line in s.splitlines(True))
 
 class ExtensionTemplate(object):
 


### PR DESCRIPTION
textwrap.indent is py3-only.