### PR TITLE
One character change in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ More concrete goals
     [this blog post](https://morepypy.blogspot.com/2018/09/inside-cpyext-why-emulating-cpython-c.html)
     for details)
 
-  - Cython will adopt this from day one: exiting Cython programs will benefit
+  - Cython will adopt this from day one: existing Cython programs will benefit
     from this automatically
 
 


### PR DESCRIPTION
I normally wouldn't care much about a typo like that, but _exiting_ might give a different impression, I hope it was meant to be _existing_ :slightly_smiling_face: